### PR TITLE
fix: drop linux/arm64 from Docker build platforms

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,7 +65,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- The Docker build workflow fails because base image `ghcr.io/linuxserver/baseimage-alpine-nginx:3.18` has no `linux/arm64` manifest.
- Drops `linux/arm64` from the `platforms:` list, building `linux/amd64` only, so this fork's CI stays green.

## Test plan
- [x] YAML change verified against the actual failing "Build and push Docker image" step (fails specifically on the multi-arch manifest for arm64).
- [ ] Confirm the next CI run on this branch succeeds.